### PR TITLE
Reworking schematic articles

### DIFF
--- a/plotsquared/installation/installation.md
+++ b/plotsquared/installation/installation.md
@@ -104,38 +104,11 @@ worlds:
 
 Replace `plotworld` with the name of your plotworld. ([Help-Page of bukkit](https://bukkit.gamepedia.com/Bukkit.yml#.2AOPTIONAL.2A_worlds))
 
-## Adding Road Schematic (optional)
+## Adding Plotworld Road Schematic (optional)
 
-Road schematics can be added after world generation. You are able to change the road schematic whenever you want, however, this will only affect newly generation regions and does not change previously generated regions. You can run `/plot regenallroads` in order to manually change already-generated roads.
+Customize the road between the plots with predefined schematics.
 
-First you want to build a road surrounding your plot. The road includes the walls, the plot border and the full intersection. Therefore you have to build over the intersections as well, we recommend going 3 or 4 blocks ahead.  +
-Advanced note: PlotSquared does only take two sides of the road into consideration when doing the road creation, because, you likely already figured, roads are squares too around the square plots. Mathematical wise you only need to know 1 side's dimension to construct a square, however, PlotSquared takes up to two sides into consideration allowing you up to two different patterns.
-
-{% hint style="info" %}
-Currently, you need a symmetrical border construction for the schematic. Otherwise you get construction mistakes.
-{% endhint %}
-
-Here is a link of the parts of a road schematic you have to create. The pink parts are just a recommendation, but the past has shown us that it's good to add them before creating the road schematic:
-
-![Road schematic](https://i.imgur.com/ISPEJPC.png)
-
-Once you have created the road, stand in the plot and execute the following command:
-
-`/plot createroadschematic`
-
-Road schematics are stored in plugins/PlotSquared/schematics/GEN_ROAD_SCHEMATIC/`worldname`. Once road schematic has been created it can be **copied** to a new `worldname` folder in this directory, providing the schematic for generating a new world.
-
-To test the schematic (recommended), stand in another plot that was not used to create the schematic. The following will regenerate the road for the plot you are standing in:
-
-`/plot debugroadregen plot`
-
-If all is well, you can begin regenerating the roads in the entire map. Open up your console and execute the following command (this may take a while and may cause lag spikes):
-
-`/plot regenallroads <world> [height]`
-
-The height option, if specified, changes the amount of air to paste above the schematic.
-
-**Another way:** you stop the server and delete the world-chunks. With the restart the new generated chunks follow your plotworld setup.
+**Instruction:** [Plotworld Road Schematic](../schematics/road-schematic.md)
 
 ## Adding Plot-Schematics (optional)
 
@@ -143,10 +116,10 @@ The height option, if specified, changes the amount of air to paste above the sc
 
 Allow to generate a plotworld with a custom schematic in all plots.
 
-**Instruction:** [Schematic generation](../schematics/schematic-generation.md)
+**Instruction:** [Plot Schematic on Generation](../schematics/schematic-generation.md)
 
 ### Plot Schematic on Claim
 
 The player get a custom plot schematic with a claim. If you wish, the player can define a plot-schematic with the claim-command.
 
-**Instruction:** [Schematic on claim](../schematics/schematic-on-claim.md)
+**Instruction:** [Plot Schematic on Claim](../schematics/schematic-on-claim.md)

--- a/plotsquared/schematics/road-schematic.md
+++ b/plotsquared/schematics/road-schematic.md
@@ -1,0 +1,57 @@
+# Plotworld Road Schematic
+
+## Introduction
+
+PlotSquared allow to customize **the road between the plots** with predefined schematics.
+
+{% hint style="tip" %}
+The road-schematics only affect the Road of the Plot world. Not the plot itself. For instructions on how to set up plot-schematics, see the articles [Plot Schematic on Generation](../schematics/schematic-generation.md) and [Plot Schematic on Claim](../schematics/schematic-on-claim.md).
+{% endhint %}
+
+{% hint style="info" %}
+Road schematics can be added after world generation. You are able to change the road schematic whenever you want, however, this will only affect [newly generation regions](#4-world-regeneration) and does not change previously generated regions.
+{% endhint %}
+
+## Setup
+
+### 1. Road Schematic Construction 
+
+First you want to build a road surrounding your plot. The road includes the walls, the plot border and the full intersection. Therefore you have to build over the intersections as well, we recommend going 3 or 4 blocks ahead.
+
+PlotSquared does only take two sides of the road into consideration when doing the road creation, because, you likely already figured, roads are squares too around the square plots. Mathematical wise you only need to know 1 side's dimension to construct a square, however, PlotSquared takes up to two sides into consideration allowing you up to two different patterns.
+
+{% hint style="info" %}
+Currently, you need a symmetrical border construction for the schematic. Otherwise you get construction mistakes.
+{% endhint %}
+
+Here is a preview of the parts of a road schematic you have to create. The pink parts are just a recommendation, but the past has shown us that it's good to add them before creating the road schematic:
+
+![Road schematic](https://i.imgur.com/ISPEJPC.png)
+
+### 2. Save the Schematic
+
+Once you have created the road, stand in the plot and execute the following command:
+
+`/plot createroadschematic`
+
+Road schematics are stored in `plugins/PlotSquared/schematics/GEN_ROAD_SCHEMATIC/<worldname>`. Once road schematic has been created it can be **copied** to a new `worldname` folder in this directory, providing the schematic for generating a new world.
+
+### 3. Testing
+
+To test the schematic (recommended), stand in another plot that was not used to create the schematic. The following will regenerate the road for the plot you are standing in:
+
+`/plot debugroadregen plot`
+
+### 4. World Regeneration
+
+#### Via Command
+
+If all is well, you can begin regenerating the roads in the entire map. Open up your console and execute the following command (this may take a while and may cause lag spikes):
+
+`/plot regenallroads <world> [height]`
+
+The height option, if specified, changes the amount of air to paste above the schematic.
+
+#### Via World Reset
+
+**Another way:** You stop the server and delete the world-chunks. With the restart the new generated chunks follow your plotworld setup.

--- a/plotsquared/schematics/road-schematic.md
+++ b/plotsquared/schematics/road-schematic.md
@@ -2,26 +2,26 @@
 
 ## Introduction
 
-PlotSquared allow to customize **the road between the plots** with predefined schematics.
+PlotSquared allows to customize **the road between the plots** with predefined schematics.
 
 {% hint style="tip" %}
-The road-schematics only affect the Road of the Plot world. Not the plot itself. For instructions on how to set up plot-schematics, see the articles [Plot Schematic on Generation](../schematics/schematic-generation.md) and [Plot Schematic on Claim](../schematics/schematic-on-claim.md).
+The road-schematics only affect the road of the plotworld. Not the plot itself. For instructions on how to set up plot-schematics, see the articles [Plot Schematic on Generation](../schematics/schematic-generation.md) and [Plot Schematic on Claim](../schematics/schematic-on-claim.md).
 {% endhint %}
 
 {% hint style="info" %}
-Road schematics can be added after world generation. You are able to change the road schematic whenever you want, however, this will only affect [newly generation regions](#4-world-regeneration) and does not change previously generated regions.
+Road schematics can be added after world generation. You are able to change the road schematic whenever you want. However, this will only affect [newly generation regions](#4-world-regeneration) and does not change previously generated regions.
 {% endhint %}
 
 ## Setup
 
 ### 1. Road Schematic Construction 
 
-First you want to build a road surrounding your plot. The road includes the walls, the plot border and the full intersection. Therefore you have to build over the intersections as well, we recommend going 3 or 4 blocks ahead.
+First, you want to build a road surrounding your plot. The road includes the walls, the plot border and the full intersection. Therefore, you have to build over the intersections as well, we recommend going 3 or 4 blocks ahead.
 
 PlotSquared does only take two sides of the road into consideration when doing the road creation, because, you likely already figured, roads are squares too around the square plots. Mathematical wise you only need to know 1 side's dimension to construct a square, however, PlotSquared takes up to two sides into consideration allowing you up to two different patterns.
 
 {% hint style="info" %}
-Currently, you need a symmetrical border construction for the schematic. Otherwise you get construction mistakes.
+Currently, you need a symmetrical border construction for the schematic. Otherwise, you get construction mistakes.
 {% endhint %}
 
 Here is a preview of the parts of a road schematic you have to create. The pink parts are just a recommendation, but the past has shown us that it's good to add them before creating the road schematic:
@@ -34,7 +34,7 @@ Once you have created the road, stand in the plot and execute the following comm
 
 `/plot createroadschematic`
 
-Road schematics are stored in `plugins/PlotSquared/schematics/GEN_ROAD_SCHEMATIC/<worldname>`. Once road schematic has been created it can be **copied** to a new `worldname` folder in this directory, providing the schematic for generating a new world.
+Road schematics are stored in `plugins/PlotSquared/schematics/GEN_ROAD_SCHEMATIC/<worldname>`. Once the road schematic has been created it can be **copied** to a new `worldname` folder in this directory, providing the schematic for generating a new world.
 
 ### 3. Testing
 
@@ -54,4 +54,4 @@ The height option, if specified, changes the amount of air to paste above the sc
 
 #### Via World Reset
 
-**Another way:** You stop the server and delete the world-chunks. With the restart the new generated chunks follow your plotworld setup.
+**Another way:** You stop the server and delete the world-chunks. With the restart, the new generated chunks follow your plotworld setup.

--- a/plotsquared/schematics/schematic-generation.md
+++ b/plotsquared/schematics/schematic-generation.md
@@ -1,8 +1,12 @@
-# Schematic generation
+# Plot Schematic on Generation
 
 ## Introduction
 
-PlotSquared allow to generate a plotworld with a custom schematic in all plots.
+PlotSquared allows to place a predefined schematic **in each plot** when generating the world.
+
+{% hint style="tip" %}
+The plot-schematics only affect the plot itself. For instructions on how to set up road-schematics for the plotworld, see the article [Plotworld Road Schematic](../schematics/road-schematic.md).
+{% endhint %}
 
 **Example:**
 

--- a/plotsquared/schematics/schematic-generation.md
+++ b/plotsquared/schematics/schematic-generation.md
@@ -14,7 +14,7 @@ The plot-schematics only affect the plot itself. For instructions on how to set 
 
 ## Setup
 
-In order to have a plot world generate with schematics do the following:
+In order to have a plotworld generate with schematics do the following:
 
 1. Create a plot schematic with `/plot schematic save`
 2. Move the created schematic from `/plugins/PlotSquared/schematics/` to `/plugins/PlotSquared/schematics/GEN_ROAD_SCHEMATIC/<world name>/` and rename it to `plot.schematic`/`plot.schem` (depending on the file extension of the schematic file you're moving)

--- a/plotsquared/schematics/schematic-on-claim.md
+++ b/plotsquared/schematics/schematic-on-claim.md
@@ -1,4 +1,12 @@
-# Schematic on claim
+# Plot Schematic on Claim
+
+## Introduction
+
+With PlotSquared you can generate a predefined plot-schematic when a player gets a new plot (`/plot claim`, `/plot auto`, ...).
+
+{% hint style="tip" %}
+The plot-schematics only affect the plot itself. For instructions on how to set up road-schematics for the plotworld, see the article [Plotworld Road Schematic](../schematics/road-schematic.md).
+{% endhint %}
 
 ## Setup
 


### PR DESCRIPTION
## Overview

Revision of the Road and Plot Schematics articles.

Fixes #9 

## Description
- For better cross-referencing, the "Road Schematic" section has been moved out.
- Tips were used to refer to the articles of the other Schematic features.
- Changing title wordings to clearly distinguish between plot and road schematics.

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
