### PR TITLE
Remove FAWE and FAVS exclusion from typo checker

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,13 +1,8 @@
-[files]
-extend-exclude = [
-    # Exclude until wikis have been updated
-    "fastasyncworldedit/**/*",
-    "fastasyncvoxelsniper/**/*",
-]
-
 [default]
 check-filename = false
 
 [default.extend-identifiers]
 # .schem extension
 "schem" = "schem"
+# sover -> s over
+"sover" = "sover"

--- a/fastasyncvoxelsniper/Entity-Brushes.md
+++ b/fastasyncvoxelsniper/Entity-Brushes.md
@@ -5,7 +5,7 @@ These brushes do not use Performers
 {% endhint %}
 
 ## The Entity Brush
-**/b en [EntityType]**: The Entity Brush allowes a user to snipe-spawn single or groups (defined by the brush size variable) of  entities from a safe distance. (Item, XPOrb, Painting, Arrow, Snowball, Fireball, SmallFireball, ThrownEnderpearl, EyeOfEnderSignal, ThrownExpBottle, PrimedTnt, FallingSand, Minecart, Boat, Creeper, Skeleton, Spider, Giant, Zombie, Slime, Ghast, PigZombie, Enderman, CaveSpider, Silverfish, Blaze, LavaSlime, EnderDragon, WitherBoss, Bat, Witch, Pig, Sheep, Cow, Chicken, Squid, Wolf, MushroomCow, SnowMan, Ozelot, VillagerGolem, Villager, EnderCrystal). *Thanks to xmlns for use of his Mob Class from SpawnMob.*
+**/b en [EntityType]**: The Entity Brush allows a user to snipe-spawn single or groups (defined by the brush size variable) of  entities from a safe distance. (Item, XPOrb, Painting, Arrow, Snowball, Fireball, SmallFireball, ThrownEnderpearl, EyeOfEnderSignal, ThrownExpBottle, PrimedTnt, FallingSand, Minecart, Boat, Creeper, Skeleton, Spider, Giant, Zombie, Slime, Ghast, PigZombie, Enderman, CaveSpider, Silverfish, Blaze, LavaSlime, EnderDragon, WitherBoss, Bat, Witch, Pig, Sheep, Cow, Chicken, Squid, Wolf, MushroomCow, SnowMan, Ozelot, VillagerGolem, Villager, EnderCrystal). *Thanks to xmlns for use of his Mob Class from SpawnMob.*
 
 {% hint style="success" %}
 After entering "/b en Sheep" and "/b 5", clicking the sniper will spawn 5 sheep at the snipe-point.

--- a/fastasyncworldedit/basic-commands/nature.md
+++ b/fastasyncworldedit/basic-commands/nature.md
@@ -21,7 +21,7 @@ The middle of the selection in the images below are marked by a yellow block.
 
 ![drain.png](https://i.imgur.com/wnjgiXJ.png)
 
-![drain_ressource.png](https://i.imgur.com/YTGLAqx.png)
+![drain_resource.png](https://i.imgur.com/YTGLAqx.png)
 
 ![drain-w.png](https://i.imgur.com/mf5arBW.png)
 
@@ -48,7 +48,7 @@ The middle of the selection in the images below are marked by a yellow block.
 
 ![fixwater-full.png](https://i.imgur.com/Krav8oA.png)
 
-![fixwater_ressource.png](https://i.imgur.com/FBuYNm4.png)
+![fixwater_resource.png](https://i.imgur.com/FBuYNm4.png)
 
 ## Fixlava
 
@@ -71,7 +71,7 @@ The middle of the selection in the images below are marked by a yellow block.
 
 ![fixlava-full.png](https://i.imgur.com/0zhsjLL.png)
 
-![fixlava_ressource.png](https://i.imgur.com/zmaFyy7.png)
+![fixlava_resource.png](https://i.imgur.com/zmaFyy7.png)
 
 ## Snow
 

--- a/fastasyncworldedit/basic-commands/navigation.md
+++ b/fastasyncworldedit/basic-commands/navigation.md
@@ -5,7 +5,7 @@
 With this command you teleport you to a specific position.
 
 * You can manually define the position with the `[world,x,y,z]` option. Else, if undefined, the command will default the target block in your [crosshair](https://minecraft.gamepedia.com/File:HUD_example.png).
-* To prevent a stuck you will teleport upstairs of the next solid block in the vertical with two free blocks in the hight for a place to stay (picture 1).
+* To prevent a stuck you will teleport upstairs of the next solid block in the vertical with two free blocks in the height for a place to stay (picture 1).
 
 ### Usage
 `//jumpto [world,x,y,z]`

--- a/fastasyncworldedit/nature.md
+++ b/fastasyncworldedit/nature.md
@@ -33,7 +33,7 @@ block.
 
 1.  ![drain.png](https://i.imgur.com/wnjgiXJ.png)
 
-2.  ![drain\_ressource.png](https://i.imgur.com/YTGLAqx.png)
+2.  ![drain\_resource.png](https://i.imgur.com/YTGLAqx.png)
 
 3.  ![drain-w.png](https://i.imgur.com/mf5arBW.png)
 
@@ -70,7 +70,7 @@ block.
 
 2.  ![fixwater-full.png](https://i.imgur.com/Krav8oA.png)
 
-3.  ![fixwater\_ressource.png](https://i.imgur.com/FBuYNm4.png)
+3.  ![fixwater\_resource.png](https://i.imgur.com/FBuYNm4.png)
 
 # Fixlava
 
@@ -103,7 +103,7 @@ block.
 
 2.  ![fixlava-full.png](https://i.imgur.com/0zhsjLL.png)
 
-3.  ![fixlava\_ressource.png](https://i.imgur.com/zmaFyy7.png)
+3.  ![fixlava\_resource.png](https://i.imgur.com/zmaFyy7.png)
 
 # Snow
 

--- a/fastasyncworldedit/navigation.md
+++ b/fastasyncworldedit/navigation.md
@@ -8,7 +8,7 @@ With this command you teleport you to a specific position.
     [crosshair](https://minecraft.gamepedia.com/File:HUD_example.png).
 
 -   To prevent a stuck you will teleport upstairs of the next solid
-    block in the vertical with two free blocks in the hight for a place
+    block in the vertical with two free blocks in the height for a place
     to stay (picture 1).
 
 ## Usage


### PR DESCRIPTION
FAWE and FAVS now use this documentation repository too, and their content has been integrated.

I propose we drop the exclusion from the typo checker, now that all content lives within this repository.