### PR TITLE
Added Move and Paste Argument Flags

### DIFF
--- a/fastasyncworldedit/basic-commands/main-commands-and-permissions.md
+++ b/fastasyncworldedit/basic-commands/main-commands-and-permissions.md
@@ -658,7 +658,7 @@ Flags:
 -a skips air blocks  
 -b include pasting biomes  
 -e include pasting entities  
--m sets a source mask so that excluded blocks become air
+-m only paste blocks matching this mask
 -n implies -s, does not paste the clipoard only the selection
 -o pastes at the original position  
 -s selects the region after pasting

--- a/fastasyncworldedit/basic-commands/main-commands-and-permissions.md
+++ b/fastasyncworldedit/basic-commands/main-commands-and-permissions.md
@@ -375,7 +375,8 @@ if they are within the same chunk.
 -s moves the selection to the target location.  
 -b also move biomes  
 -e also move entities  
--a ignores air  
+-a ignores air
+-m set the include mask, non-matching blocks become air
 Optionally fills the old location with .
 
 #### //forest [type] [density]

--- a/fastasyncworldedit/basic-commands/main-commands-and-permissions.md
+++ b/fastasyncworldedit/basic-commands/main-commands-and-permissions.md
@@ -660,7 +660,7 @@ Flags:
 -b include pasting biomes  
 -e include pasting entities  
 -m only paste blocks matching this mask
--n implies -s, does not paste the clipoard only the selection
+-n implies -s, does not paste the clipboard only the selection
 -o pastes at the original position  
 -s selects the region after pasting
 

--- a/fastasyncworldedit/basic-commands/main-commands-and-permissions.md
+++ b/fastasyncworldedit/basic-commands/main-commands-and-permissions.md
@@ -656,8 +656,10 @@ WARNING: Cutting and pasting entities cannot yet be undone!
 *Desc*: Pastes the clipboard's contents.  
 Flags:  
 -a skips air blocks  
--b skips pasting biomes  
--e skips pasting entities  
+-b include pasting biomes  
+-e include pasting entities  
+-m sets a source mask so that excluded blocks become air
+-n implies -s, does not paste the clipoard only the selection
 -o pastes at the original position  
 -s selects the region after pasting
 

--- a/fastasyncworldedit/basic-commands/main-commands-and-permissions.md
+++ b/fastasyncworldedit/basic-commands/main-commands-and-permissions.md
@@ -372,9 +372,9 @@ if they are within the same chunk.
 
 *Perm*: `worldedit.region.move`   
 *Desc*: Moves the contents of the selection.  
--s flag shifts the selection to the target location.  
--b also copies biomes  
--e ignores entities  
+-s moves the selection to the target location.  
+-b also move biomes  
+-e also move entities  
 -a ignores air  
 Optionally fills the old location with .
 


### PR DESCRIPTION
## Overview

Some flags of the paste and move command are wrong or missing, this PR adds the missing flags and tries to fix the wrong flags.

## Description

### Move command argument flags

Source: [https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/fe626a92e14ec1fb9db38a52895c131c9230443b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java#L539](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/fe626a92e14ec1fb9db38a52895c131c9230443b/worldedit-core/src/main/java/com/sk89q/worldedit/command/RegionCommands.java#L539)

- `-b` includes moving biomes, not excluding them
- `-e` includes moving entities, not excluding them
- `-m` added this flag

### Paste command argument flags

Source: [https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/fe626a92e14ec1fb9db38a52895c131c9230443b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java#L500](https://github.com/IntellectualSites/FastAsyncWorldEdit/blob/fe626a92e14ec1fb9db38a52895c131c9230443b/worldedit-core/src/main/java/com/sk89q/worldedit/command/ClipboardCommands.java#L500)

- `-b` includes moving biomes, not excluding them
- `-e` includes moving entities, not excluding them
- `-m` added this flag
- `-n` added this flag

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
