### PR TITLE
Fix linking of pattern

### DIFF
--- a/plotsquared/block-bucket.md
+++ b/plotsquared/block-bucket.md
@@ -13,7 +13,7 @@ Blocks can be in the format `namespace:block[property1=value1,property2=value2]`
 
 Complex patterns are also accepted:
 
-* [FAWE Patterns](/fastasyncworldedit/advanced-features/patterns.md) (If you have FAWE installed)
+* [FAWE Patterns](/fastasyncworldedit/patterns.md) (If you have FAWE installed)
 * [WorldEdit Patterns](https://worldedit.enginehub.org/en/latest/usage/general/patterns/)
 
 ## Disallowed Blocks


### PR DESCRIPTION
## Overview
Fixes #80

## Description
As there is no subfolder with "advanced-features" I have now simply removed it. It now links to the following page: 
https://intellectualsites.gitbook.io/fastasyncworldedit/command-utilities/patterns

```[tasklist]
### Submitter Checklist
- [X] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
