### PR TITLE
Fix inadequate documentation of commands "move", "copy", and "swap".

### DIFF
--- a/plotsquared/commands.md
+++ b/plotsquared/commands.md
@@ -810,10 +810,6 @@ _Primary:_
 
 * `plots.copy` - Access to the command `/plot copy`
 
-_Secondary:_
-
-* `plots.admin` - Allows overriding plots that you don't own.
-
 **Source Code:** [here](https://github.com/IntellectualSites/PlotSquared/blob/main/Core/src/main/java/com/plotsquared/core/command/Copy.java)
 
 ### MOVE
@@ -829,10 +825,6 @@ The plot that was specified after the command will be replaced with the plot you
 _Primary:_
 
 * `plots.move` - Access to the command `/plot move`
-
-_Secondary:_
-
-* `plots.admin` - Allows overriding plots that you don't own.
 
 **Source Code:** [here](https://github.com/IntellectualSites/PlotSquared/blob/main/Core/src/main/java/com/plotsquared/core/command/Move.java)
 
@@ -852,10 +844,6 @@ The plot that was specified after the command will be swapped with the plot you 
 _Primary:_
 
 * `plots.swap` - Access to the command `/plot swap`
-
-_Secondary:_
-
-* `plots.admin` - Allows overriding plots that you don't own.
 
 **Source Code:** [here](https://github.com/IntellectualSites/PlotSquared/blob/main/Core/src/main/java/com/plotsquared/core/command/Swap.java)
 

--- a/plotsquared/commands.md
+++ b/plotsquared/commands.md
@@ -796,6 +796,7 @@ _Secondary:_
 ### COPY
 
 Copy a plot.
+The plot that was specified after the command will be replaced with the plot you are in or have specified before the command.
 
 **Usage:**
 `/plot [[world;]X;Z] copy <X;Z>`
@@ -809,11 +810,16 @@ _Primary:_
 
 * `plots.copy` - Access to the command `/plot copy`
 
+_Secondary:_
+
+* `plots.admin` - Allows overriding plots that you don't own.
+
 **Source Code:** [here](https://github.com/IntellectualSites/PlotSquared/blob/main/Core/src/main/java/com/plotsquared/core/command/Copy.java)
 
 ### MOVE
 
 Move a plot.
+The plot that was specified after the command will be replaced with the plot you are in or have specified before the command. After replacing the plot, the plot that you are in or have specified before the command will be removed.
 
 **Usage:**
 `/plot [[world;]X;Z] move <X;Z>`
@@ -824,11 +830,16 @@ _Primary:_
 
 * `plots.move` - Access to the command `/plot move`
 
+_Secondary:_
+
+* `plots.admin` - Allows overriding plots that you don't own.
+
 **Source Code:** [here](https://github.com/IntellectualSites/PlotSquared/blob/main/Core/src/main/java/com/plotsquared/core/command/Move.java)
 
 ### SWAP
 
 Swap two plots.
+The plot that was specified after the command will be swapped with the plot you are in or have specified before the command.
 
 **Usage:**
 `/plot [[world;]X;Z] swap <X;Z>`
@@ -841,6 +852,10 @@ Swap two plots.
 _Primary:_
 
 * `plots.swap` - Access to the command `/plot swap`
+
+_Secondary:_
+
+* `plots.admin` - Allows overriding plots that you don't own.
 
 **Source Code:** [here](https://github.com/IntellectualSites/PlotSquared/blob/main/Core/src/main/java/com/plotsquared/core/command/Swap.java)
 


### PR DESCRIPTION
## Overview
The commands "move", "copy" and "swap" have had documentation modified as part of this PR.

I think this will clear up some confusion as apart of these commands while keeping with the original
documentation format. Mainly that I accidentally deleted a plot due to this inadequate documentation 🙃.

## Description
The commands "move", "copy" and "swap" have had documentation modified as part of this commit.

```[tasklist]
### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
```
