### PR TITLE
docs: correct typos and style inconsistencies in why‑plotsquared.md

### DIFF
--- a/plotsquared/why-plotsquared.md
+++ b/plotsquared/why-plotsquared.md
@@ -3,22 +3,22 @@
 ## Support
 
 * Works on SpigotMC and PaperMC server systems
-* Support for Minecraft 1.13.2 to 1.20.x
+* Support for Minecraft 1.13.2 to 1.21.x
 * Works with offline-mode servers
 * Is considered a world generator and is therefore supported by most world management tools, such as [MultiverseCore](https://www.spigotmc.org/resources/390)
 * [Community Translations](https://intellectualsites.crowdin.com/plotsquared)
-* fast [Discord](https://discord.gg/intellectualsites) support
+* Fast [Discord](https://discord.gg/intellectualsites) support
 * Very popular for the players
 
 ## Speed
 
 * Plots are cleared asynchronously and are therefore particularly high-performance
-* Plot auto doesn't lag or crash the server
+* Auto-plotting doesn't lag or crash the server
 * Much faster chunk generation, plot moving, swapping + everything
 * Supports huge plot sizes (e.g. 1024x1024 of custom terrain)
 * Works with hundreds of thousands of plots
 
-## Reduce lag
+## Reduce Lag
 
 * Optional plot purging and old plot removal
 * Optional dynamic world border and world chunk trimming
@@ -30,11 +30,11 @@
 
 * Distinction between different [membership tiers](plot-membership-tiers.md)
 * Per plot use / interact flags for different materials and some other restrictions via [plot flags](plot-flags.md)
-* You have a reliable [WorldEdit](https://dev.bukkit.org/projects/worldedit) / [FastAsyncWorldEdit](https://www.spigotmc.org/resources/13932) restriction
-* With using of FAWE, you have a reliable [FastAsyncVoxelSniper](https://github.com/IntellectualSites/fastasyncvoxelsniper) restriction too
+* Reliable [WorldEdit](https://dev.bukkit.org/projects/worldedit) / [FastAsyncWorldEdit](https://www.spigotmc.org/resources/13932) restrictions
+* Realiable [FastAsyncVoxelSniper](https://github.com/IntellectualSites/fastasyncvoxelsniper) restrictions also apply when using FAWE
 * Chunk and WorldEdit processor to prevent lag, crashes and data corruption
 * Many permissions
-* Lots of redundancies. e.g. Backup your database with `/plot database`, or if you loose both, you can still recover based on plot sign information
+* Lots of redundancies. e.g. Backup your database with `/plot database`, or if you lose both, you can still recover based on plot sign information
 
 ## Looks
 
@@ -45,17 +45,17 @@
 
 ## Features
 
-* Plot merging, moving and plot switch
+* Plot merging, moving and plot switching
 * Extensive flag system (~100+ flags)
 * Plot clusters in normal worlds
 * Augmented generation (e.g. Vanilla, Islands, TerrainControl)
-* PlotSquared Web interface with plot infos
+* PlotSquared Web interface with plot info
 * Plot components with percent composition control
 * plot-chat, plot-rate, mark a plot as _done_
-* and much more ...
+* And much more...
 
 ## Official plugins and plugin support
 * Plot-Regions on Dynmap with [Plot2Dynmap](https://www.spigotmc.org/resources/1292)
-* Plot-Hologramms as alternative to the plot-signs with [HoloPlots](https://www.spigotmc.org/resources/4880)
+* Plot-Holograms as alternative to the plot-signs with [HoloPlots](https://www.spigotmc.org/resources/4880)
 * Hide a specific plot with [PlotHider](https://www.spigotmc.org/resources/20701)
 * New Placeholders for [PlaceholderAPI](https://www.spigotmc.org/resources/6245)

--- a/plotsquared/why-plotsquared.md
+++ b/plotsquared/why-plotsquared.md
@@ -31,7 +31,7 @@
 * Distinction between different [membership tiers](plot-membership-tiers.md)
 * Per plot use / interact flags for different materials and some other restrictions via [plot flags](plot-flags.md)
 * Reliable [WorldEdit](https://dev.bukkit.org/projects/worldedit) / [FastAsyncWorldEdit](https://www.spigotmc.org/resources/13932) restrictions
-* Realiable [FastAsyncVoxelSniper](https://github.com/IntellectualSites/fastasyncvoxelsniper) restrictions also apply when using FAWE
+* Reliable [FastAsyncVoxelSniper](https://github.com/IntellectualSites/fastasyncvoxelsniper) restrictions also apply when using FAWE
 * Chunk and WorldEdit processor to prevent lag, crashes and data corruption
 * Many permissions
 * Lots of redundancies. e.g. Backup your database with `/plot database`, or if you lose both, you can still recover based on plot sign information


### PR DESCRIPTION
## Overview
Typos and style inconsistencies in **why-plotsquared.md**

## Description
- Uniform version range notation (1.13.2–1.21.x)
- Consistent heading capitalization
- Grammar and phrasing improvements
- Cleaned up list item punctuation and overall formatting

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
