### PR TITLE
Fix flag-api typo and clarified instance initialization timing

### DIFF
--- a/plotsquared/api/flag-api.md
+++ b/plotsquared/api/flag-api.md
@@ -104,7 +104,9 @@ All flags must be registered in the `GlobalFlagContainer`, or else they will not
 Each flag will be applied to every plot, so it is necessary to pick appropriate default flag values.
 
 To register a flag, use:
-`com.plotsquared.plot.flags.GlobalFlagContainer().getInstance().addFlag(flagInstance)`
+`com.plotsquared.plot.flags.GlobalFlagContainer.getInstance().addFlag(flagInstance)`
+
+`GlobalFlagContainer` instance will be initialized after the plugin is enabled, calling `GlobalFlagContainer.getInstance()` before enable will always return null.
 
 ## Adding a flag to a plot
 


### PR DESCRIPTION
## Overview

Some corrections to the PlotSquared flag-api doc, and clarified instance initialization timing.

## Description

Clarifying the GlobalFlagContainer initialization stage

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
